### PR TITLE
Update sources: mozilla.org, remove en-US from iOS

### DIFF
--- a/app/sources/firefox_ios.txt
+++ b/app/sources/firefox_ios.txt
@@ -12,7 +12,6 @@ da
 de
 dsb
 el
-en-US
 eo
 es
 es-CL

--- a/app/sources/mozilla_org.txt
+++ b/app/sources/mozilla_org.txt
@@ -45,6 +45,7 @@ he
 hi-IN
 hr
 hsb
+hto
 hu
 hy-AM
 id
@@ -79,9 +80,11 @@ nn-NO
 oc
 or
 pa-IN
+pbb
 pl
 pt-BR
 pt-PT
+qvi
 rm
 ro
 ru
@@ -100,6 +103,7 @@ th
 tl
 tn
 tr
+trs
 tsz
 uk
 ur


### PR DESCRIPTION
We can remove en-US, since Transvision automatically add the reference
locale in the list
https://github.com/mozfr/transvision/blob/master/app/classes/Transvision
/Project.php#L175-L180
